### PR TITLE
preventing install-jenkins-plugin resource to fail due to

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,6 +117,7 @@ class jenkins::repo::debian {
 
 define install-jenkins-plugin($name, $version=0) {
   $plugin     = "${name}.hpi"
+  $plugin_parent_dir = "/var/lib/jenkins"
   $plugin_dir = "/var/lib/jenkins/plugins"
 
   if ($version != 0) {
@@ -128,7 +129,7 @@ define install-jenkins-plugin($name, $version=0) {
 
   if (!defined(File["${plugin_dir}"])) {
     file {
-      "${plugin_dir}" :
+      [$plugin_parent_dir, $plugin_dir]:
         owner  => "jenkins",
         ensure => directory;
     }


### PR DESCRIPTION
I had the following message after trying to provision jenkins on a sample machine:

err: /Stage[main]//Install-jenkins-plugin[git-plugin]/File[/var/lib/jenkins/plugins]/ensure: change from absent to directory failed: Cannot create /var/lib/jenkins/plugins; parent directory /var/lib/jenkins does not exist

This error made all my plugins not to be installed. 

This fix solved this specific issue. This is a very small contribution, thanks a lot for developing this very useful puppet module, saved me a lot of work.
