### PR TITLE
Fix jenkins::firewall in case you don't have puppetlabs-firewall.

### DIFF
--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -1,6 +1,6 @@
 class jenkins::firewall {
-  if defined('firewall') {
-    firewall {
+  if defined('::firewall') {
+    ::firewall {
       '500 allow Jenkins inbound traffic':
         action => 'accept',
         state  => 'NEW',


### PR DESCRIPTION
In case you don't have puppetlabs-firewall, the defined('firewall') still evaluates to true because of scoping: there's a firewall class in the jenkins namespace (indeed, we're inside that jenkins::firewall class). Puppet therefore complains that the type Firewall doesn't exist on the next line.
Using defined('::firewall') fixes the issue, and for consistency let's use ::firewall on the next line too.
