### PR TITLE
Avoid duplicate File['/etc/apt/sources.list.d'] by checking whether it's...

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,8 +1,11 @@
 class jenkins::repo::debian {
+  if !defined(File['/etc/apt/sources.list.d']) {
+    file {
+        '/etc/apt/sources.list.d' :
+            ensure => directory,
+    }
+  }
   file {
-      '/etc/apt/sources.list.d' :
-          ensure => directory;
-
       '/etc/apt/sources.list.d/jenkins.list' :
           ensure => present,
           notify => [


### PR DESCRIPTION
... already defined.

Other modules define a File['/etc/apt/sources.list.d'](e.g. https://github.com/puppetlabs/puppet-apt/blob/master/manifests/init.pp#L56), so they will conflict with puppet-jenkins.
