### PR TITLE
Mock apt::source define in spec tests. fixes #9

### DIFF
--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -22,6 +22,24 @@ describe 'jenkins' do
   end
 
   deb_operatingsystems.each do |os|
+    let :pre_condition do
+      " define apt::source (
+          $location          = '',
+          $release           = $lsbdistcodename,
+          $repos             = 'main',
+          $include_src       = true,
+          $required_packages = false,
+          $key               = false,
+          $key_server        = 'keyserver.ubuntu.com',
+          $key_content       = false,
+          $key_source        = false,
+          $pin               = false
+        ) {
+          notify { 'mock apt::source $title':; }
+        }
+      "
+    end
+
     describe "on #{os}" do
       let(:facts) do
         { 'operatingsystem' => os }


### PR DESCRIPTION
This commit pre-defines apt::source in spec/classes/jenkins_spec.rb in order to be able to successfully run rspec-puppet tests without needing the apt module present in the environment.

Yes, it's a hack.

"[...] The problem is that I (being a dirty rpm user) shouldn't need to pull puppet-apt into the environment to run these tests [...]" ~ rtyler

See: https://github.com/rtyler/puppet-jenkins/issues/9
