### PR TITLE
Fix Could not find group jenkins error

### DIFF
--- a/manifests/plugin/install.pp
+++ b/manifests/plugin/install.pp
@@ -19,10 +19,17 @@ define jenkins::plugin::install($version=0) {
     }
   }
 
+  if (!defined(Group['jenkins'])) {
+    group {
+      'jenkins' :
+        ensure => present;
+    }
+  }
   if (!defined(User['jenkins'])) {
     user {
       'jenkins' :
-        ensure => present;
+        ensure => present,
+        gid    => 'jenkins';
     }
   }
 

--- a/spec/defines/jenkins_plugin_install_spec.rb
+++ b/spec/defines/jenkins_plugin_install_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+# Note, rspec-puppet determines the define name from the top level describe
+# string.
+describe 'jenkins::plugin::install' do
+  let(:title) { 'git' }
+  it { should contain_user('jenkins') }
+  it { should contain_group('jenkins') }
+  it { should contain_file('/var/lib/jenkins') }
+  it { should contain_file('/var/lib/jenkins/plugins') }
+  it { should contain_exec('download-git') }
+end
+


### PR DESCRIPTION
Without this patch applied, the Jenkins module fails on Lucid when
managing a jenkins::plugin::install resource.  This is a problem because
the catalog cannot compile and the system is not configured.

The error looks like:

```
err: /Stage[main]/Site::Jenkins_plugins/Jenkins::Plugin::Install[git]/File[/var/lib/jenkins]:
    Could not evaluate: Could not find group jenkins
```

This error is caused because the file resource specfies group =>
jenkins, but the defined type does not manage a Group[jenkins] resource,
only a User[jenkins] resource.

This patch fixes the problem by managing Group[jenkins] similar to how
User[jenkins] is already managed.

This fixes the issue and adds rspec-puppet tests to cover the common
resource of Jenkins::Plugin::Install[git]
