### PR TITLE
Adding version configuration to Jenkins::Package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,14 @@
-class jenkins {
+class jenkins($version = 'installed') {
   package {
     'jre':
         ensure => '1.7.0',
         noop   => true
   }
   include jenkins::repo
-  include jenkins::package
+  class {
+    'jenkins::package':
+      version => $version,
+  }
   include jenkins::service
   include jenkins::firewall
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,7 +1,7 @@
-class jenkins::package {
+class jenkins::package($version = 'installed') {
   package {
     'jenkins' :
-      ensure => installed;
+      ensure => $version;
   }
 }
 


### PR DESCRIPTION
Hi,

So I added a version configuration parameter to Jenkins::Package (and Jenkins so it would pass through). I needed this so I could reliably redeploy a given jenkins system and have it work with my specified plugin versions. When used the traditional way (include jenkins) defaults make the module behave as it classically has, a version can be specified like 

```
class {
  'jenkins':
    version => '1.467-1.1',
}
```

Thanks,
-Chris
