### PR TITLE
Fix puppet-jenkins for Debian/Ubuntu

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,7 +1,7 @@
 class jenkins::repo::debian {
   apt::source { 'jenkins':
     location    => 'http://pkg.jenkins-ci.org/debian',
-    release     => '',
+    release     => $lsbdistcodename,
     repos       => 'binary/',
     key         => 'D50582E6',
     key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',


### PR DESCRIPTION
With the current version 0.2.3 running `sudo puppet apply -v -e 'include jenkins'` aborts with

```
lsbdistcodename fact not available: release parameter required at /etc/puppet/modules/apt/manifests/source.pp:25
```

on Ubuntu 12.04.

The problem seems to be that an empty string is passed to `apt::source`, which for some reason can not access `$lsbdistcodename`. This patch fixes the issue for me by falling back to `$lsbdistcodename` immediately instead of passing an empty string.
