### PR TITLE
Changes to improve support on RHEL and Debian-based OSes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -83,7 +83,9 @@ To quickly try this module with the puppet module tool:
     info: Loading facts in facter_dot_d
     info: Loading facts in facter_dot_d
     info: Applying configuration version '1323459431'
-    notice: /Stage[main]/Jenkins::Repo::El/File[/etc/yum.repos.d/jenkins.repo]/ensure: defined content as '{md5}0a907e1f316e481ab145edaa6ba66d39'
+    notice: /Stage[main]/Jenkins::Repo::El/Yumrepo[jenkins]/descr: descr changed '' to 'Jenkins'
+    notice: /Stage[main]/Jenkins::Repo::El/Yumrepo[jenkins]/baseurl: baseurl changed '' to 'http://pkg.jenkins-ci.org/redhat/'
+    notice: /Stage[main]/Jenkins::Repo::El/Yumrepo[jenkins]/gpgcheck: gpgcheck changed '' to '1'
     notice: /Stage[main]/Jenkins::Repo::El/File[/etc/yum/jenkins-ci.org.key]/ensure: defined content as '{md5}9fa06089848262c5a6383ec27fdd2575'
     notice: /Stage[main]/Jenkins::Repo::El/Exec[rpm --import /etc/yum/jenkins-ci.org.key]/returns: executed successfully
     notice: /Stage[main]/Jenkins::Package/Package[jenkins]/ensure: created

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -2,22 +2,22 @@ class jenkins::repo {
   # JJM These anchors work around #8040
   anchor { 'jenkins::repo::alpha': }
   anchor { 'jenkins::repo::omega': }
-  case $::operatingsystem {
-    centos, redhat, oel, Amazon: {
+  case $::osfamily {
+    'RedHat': {
       class { 'jenkins::repo::el':
         require => Anchor['jenkins::repo::alpha'],
         before  => Anchor['jenkins::repo::omega'],
       }
     }
-    opensuse: {
-      # XXX: Need to figure out how to set up the zypper repo for openSUSE
-    }
-
-    default: {
+    'Debian': {
       class { 'jenkins::repo::debian':
         require => Anchor['jenkins::repo::alpha'],
         before  => Anchor['jenkins::repo::omega'],
       }
+    }
+
+    default: {
+      fail( "Unsupported OS family: ${::osfamily}" )
     }
   }
 }

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -4,8 +4,10 @@ class jenkins::repo::el {
     group => 'root',
     mode  => 0644,
   }
-  file { '/etc/yum.repos.d/jenkins.repo':
-    content => template("${module_name}/jenkins.repo"),
+  yumrepo {'jenkins':
+    descr    => 'Jenkins',
+    baseurl  => 'http://pkg.jenkins-ci.org/redhat/',
+    gpgcheck => 1,
   }
   file { '/etc/yum/jenkins-ci.org.key':
     content => template("${module_name}/jenkins-ci.org.key"),

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -3,49 +3,45 @@ require 'spec_helper'
 # Note, rspec-puppet determines the class name from the top level describe
 # string.
 describe 'jenkins' do
-  it { should contain_class 'jenkins' }
-  it { should contain_class 'jenkins::repo' }
-  it { should contain_class 'jenkins::package' }
-  it { should contain_class 'jenkins::service' }
-
-  rpm_operatingsystems = [ "RedHat", "CentOS" ]
-  deb_operatingsystems = [ "Ubuntu", "Debian" ]
-
-  rpm_operatingsystems.each do |os|
-    describe "on #{os}" do
-      let(:facts) do
-        { 'operatingsystem' => os }
-      end
-      it { should contain_class 'jenkins::repo::el' }
-      it { should_not contain_class 'jenkins::repo::debian' }
+  describe "on RedHat" do
+    let(:facts) do
+      { :osfamily => 'RedHat' }
     end
+    it { should contain_class 'jenkins' }
+    it { should contain_class 'jenkins::repo' }
+    it { should contain_class 'jenkins::package' }
+    it { should contain_class 'jenkins::service' }
+    it { should contain_class 'jenkins::repo::el' }
+    it { should_not contain_class 'jenkins::repo::debian' }
   end
 
-  deb_operatingsystems.each do |os|
-    let :pre_condition do
-      " define apt::source (
-          $location          = '',
-          $release           = $lsbdistcodename,
-          $repos             = 'main',
-          $include_src       = true,
-          $required_packages = false,
-          $key               = false,
-          $key_server        = 'keyserver.ubuntu.com',
-          $key_content       = false,
-          $key_source        = false,
-          $pin               = false
-        ) {
-          notify { 'mock apt::source $title':; }
-        }
-      "
-    end
+  let(:facts) do
+    { :osfamily => 'Debian' }
+  end
+  let :pre_condition do
+    " define apt::source (
+        $location          = '',
+        $release           = $lsbdistcodename,
+        $repos             = 'main',
+        $include_src       = true,
+        $required_packages = false,
+        $key               = false,
+        $key_server        = 'keyserver.ubuntu.com',
+        $key_content       = false,
+        $key_source        = false,
+        $pin               = false
+      ) {
+        notify { 'mock apt::source $title':; }
+      }
+    "
+  end
 
-    describe "on #{os}" do
-      let(:facts) do
-        { 'operatingsystem' => os }
-      end
-      it { should contain_class 'jenkins::repo::debian' }
-      it { should_not contain_class 'jenkins::repo::el' }
-    end
+  describe "on Debian" do
+    it { should contain_class 'jenkins' }
+    it { should contain_class 'jenkins::repo' }
+    it { should contain_class 'jenkins::package' }
+    it { should contain_class 'jenkins::service' }
+    it { should contain_class 'jenkins::repo::debian' }
+    it { should_not contain_class 'jenkins::repo::el' }
   end
 end

--- a/spec/defines/jenkins_plugin_install_spec.rb
+++ b/spec/defines/jenkins_plugin_install_spec.rb
@@ -4,10 +4,26 @@ require 'spec_helper'
 # string.
 describe 'jenkins::plugin::install' do
   let(:title) { 'git' }
-  it { should contain_user('jenkins') }
-  it { should contain_group('jenkins') }
-  it { should contain_file('/var/lib/jenkins') }
-  it { should contain_file('/var/lib/jenkins/plugins') }
-  it { should contain_exec('download-git') }
+
+  describe "on RedHat" do
+    let(:facts) do
+      { :osfamily => 'RedHat' }
+    end
+    it { should contain_user('jenkins') }
+    it { should contain_group('jenkins') }
+    it { should contain_file('/var/lib/jenkins') }
+    it { should contain_file('/var/lib/jenkins/plugins') }
+    it { should contain_exec('download-git') }
+  end
+  describe "on Debian" do
+    let(:facts) do
+      { :osfamily => 'Debian' }
+    end
+    it { should contain_user('jenkins') }
+    it { should contain_group('jenkins') }
+    it { should contain_file('/var/lib/jenkins') }
+    it { should contain_file('/var/lib/jenkins/plugins') }
+    it { should contain_exec('download-git') }
+  end
 end
 

--- a/templates/jenkins.repo
+++ b/templates/jenkins.repo
@@ -1,4 +1,0 @@
-[jenkins]
-name=Jenkins
-baseurl=http://pkg.jenkins-ci.org/redhat
-gpgcheck=1


### PR DESCRIPTION
Module now supports $::osfamily fact instead of $::operatingsystem
for determining install type.  This is based on ekohl's work - 
https://github.com/rtyler/puppet-jenkins/pull/25

Modify spec tests to also check osfamily fact, and fix broken tests
on RHEL-based systems.
