### PR TITLE
Unable to install plugins if user jenkins has a duplicate UID

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -36,12 +36,20 @@ define jenkins::plugin($version=0) {
 
   exec {
     "download-${name}" :
-      command  => "wget --no-check-certificate ${base_url}${plugin}",
-      cwd      => $plugin_dir,
-      require  => File[$plugin_dir],
-      path     => ['/usr/bin', '/usr/sbin',],
-      user     => 'jenkins',
-      unless   => "test -f ${plugin_dir}/${plugin}",
-      notify   => Service['jenkins'];
+      command    => "wget --no-check-certificate ${base_url}${plugin}",
+      cwd        => '/tmp',
+      path       => ['/usr/bin', '/usr/sbin',],
+      unless     => "test -f ${plugin_dir}/${plugin}",
+      notify     => Exec["install-${name}"],
+  }
+
+  exec {
+    "install-${name}" :
+      command     => "chown jenkins ${plugin} && mv ${plugin} $plugin_dir",
+      cwd         => '/tmp',
+      refreshonly => true,
+      require     => [ Exec["download-${name}"], File[$plugin_dir] ],
+      path        => ['/bin'],
+      notify      => Service['jenkins'];
   }
 }


### PR DESCRIPTION
I need to have jenkins sharing UID with www-data and I had problems when trying to install modules

To prevent it I do it in two steps.
First we download the file to /tmp, and then move and chown to plugin_dir
