### PR TITLE
Unable to install plugins if user jenkins has a duplicate UID

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -24,7 +24,7 @@ define jenkins::plugin($version=0) {
     group {
       'jenkins' :
         ensure => present;
-    }
+    } 
   }
 
   if (!defined(User['jenkins'])) {
@@ -37,19 +37,17 @@ define jenkins::plugin($version=0) {
   exec {
     "download-${name}" :
       command    => "wget --no-check-certificate ${base_url}${plugin}",
-      cwd        => '/tmp',
+      cwd        => $plugin_dir,
+      require    => File[$plugin_dir],
       path       => ['/usr/bin', '/usr/sbin',],
       unless     => "test -f ${plugin_dir}/${plugin}",
-      notify     => Exec["install-${name}"],
   }
 
-  exec {
-    "install-${name}" :
-      command     => "chown jenkins ${plugin} && mv ${plugin} $plugin_dir",
-      cwd         => '/tmp',
-      refreshonly => true,
-      require     => [ Exec["download-${name}"], File[$plugin_dir] ],
-      path        => ['/bin'],
-      notify      => Service['jenkins'];
+  file {
+    "$plugin_dir/$plugin" :
+      require => Exec["download-${name}"],
+      owner   => 'jenkins',
+      mode    => 644,
+      notify  => Service['jenkins']
   }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -36,12 +36,20 @@ define jenkins::plugin($version=0) {
 
   exec {
     "download-${name}" :
-      command  => "wget --no-check-certificate ${base_url}${plugin}",
-      cwd      => $plugin_dir,
-      require  => File[$plugin_dir],
-      path     => ['/usr/bin', '/usr/sbin',],
-      user     => 'jenkins',
-      unless   => "test -f ${plugin_dir}/${plugin}",
-      notify   => Service['jenkins'];
+      command    => "wget --no-check-certificate ${base_url}${plugin}",
+      cwd        => '/tmp',
+      path       => ['/usr/bin', '/usr/sbin',],
+      unless     => "test -f ${plugin_dir}/${plugin}",
+      notify     => Exec["install-${name}"],
+  }
+
+  exec {
+    "install-${name}" :
+      command     => "chown jenkins ${plugin} && mv ${plugin} $plugin_dir",
+      cwd         => '/tmp',
+      refreshonly => true,
+      require     => [ Exec["download-${name}"], File[$plugin_dir] ],
+      path        => ['/bin'],
+      notify      => Service['jenkins'];
   }
 }


### PR DESCRIPTION
I need to have jenkins sharing UID with www-data and I had problems when trying to install modules

I found out that puppet doesnt like much trying to run commands as user 'jenkins' when he has UID 33 and other user also has UID 33

To workaround it, I do the exec to download the plugin as root, and then use a file resource to correct file ownership
That seems to work fine :)

I did a previous pull request, but cancelled it because of its dirtyness. Sorry
