### PR TITLE
use jpi file as default

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,5 +1,5 @@
 define jenkins::plugin($version=0) {
-  $plugin            = "${name}.hpi"
+  $plugin            = "${name}.jpi"
   $plugin_dir        = '/var/lib/jenkins/plugins'
   $plugin_parent_dir = '/var/lib/jenkins'
 


### PR DESCRIPTION
Looks like now that jenkins use jpi file, using the "hpi" as default extension make puppet trying to reinstall plugins at every run, as jenkins rename them from hpi to jpi.

I think all plugins are available as jpi, so it could be good to move to jpi as default for plugin names
