### PR TITLE
support lts param in debian repo class

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,4 +1,5 @@
-class jenkins::repo::debian {
+class jenkins::repo::debian ( $lts=0 )
+{
     if $lts == 0 {
 	    apt::source { 'jenkins':
 	      location    => 'http://pkg.jenkins-ci.org/debian',


### PR DESCRIPTION
This is a second pull request for the same change : support of lts param in debian repo class.
