### PR TITLE
Setup on Debian broken due to missing $lts param

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,37 +1,36 @@
 class jenkins::repo ( $lts = 0, $repo = 1 )
-	{
+{
   # JJM These anchors work around #8040
   anchor { 'jenkins::repo::alpha': }
   anchor { 'jenkins::repo::omega': }
   
   if $repo == 1 {
-	  case $::osfamily {
-	    'RedHat': {
-	      class { 'jenkins::repo::el':
-			lts  => $lts,
-	        require => Anchor['jenkins::repo::alpha'],
-	        before  => Anchor['jenkins::repo::omega'],
-	      }
-	    }
-	    'Linux': {
-	      class { 'jenkins::repo::el':
-			lts  => $lts,
-	        require => Anchor['jenkins::repo::alpha'],
-	        before  => Anchor['jenkins::repo::omega'],
-	      }
-	    }
-	    'Debian': {
-	      class { 'jenkins::repo::debian':
-			lts  => $lts,
-		    require => Anchor['jenkins::repo::alpha'],
-	        before  => Anchor['jenkins::repo::omega'],
-	      }
-	    }
-
-	    default: {
-	      fail( "Unsupported OS family: ${::osfamily}" )
-	    }
-	  }
+    case $::osfamily {
+      'RedHat': {
+        class { 'jenkins::repo::el':
+          lts  => $::jenkins::repo::lts,
+          require => Anchor['jenkins::repo::alpha'],
+          before  => Anchor['jenkins::repo::omega'],
+        }
+      }
+      'Linux': {
+        class { 'jenkins::repo::el':
+          lts  => $::jenkins::repo::lts,
+          require => Anchor['jenkins::repo::alpha'],
+          before  => Anchor['jenkins::repo::omega'],
+        }
+      }
+      'Debian': {
+        class { 'jenkins::repo::debian':
+          lts  => $::jenkins::repo::lts,
+          require => Anchor['jenkins::repo::alpha'],
+          before  => Anchor['jenkins::repo::omega'],
+        }
+      }
+      default: {
+        fail( "Unsupported OS family: ${::osfamily}" )
+      }
+    }
   }
 }
 

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,24 +1,23 @@
-class jenkins::repo::debian {
-    if $lts == 0 {
-	    apt::source { 'jenkins':
-	      location    => 'http://pkg.jenkins-ci.org/debian',
-	      release     => 'binary/',
-	      repos       => '',
-	      key         => 'D50582E6',
-	      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-	      include_src => false,
-	    }
-
+class jenkins::repo::debian ( $lts=0 )
+{
+  if $lts == 0 {
+    apt::source { 'jenkins':
+      location    => 'http://pkg.jenkins-ci.org/debian',
+      release     => 'binary/',
+      repos       => '',
+      key         => 'D50582E6',
+      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      include_src => false,
     }
-    elsif $lts == 1 {
-	    apt::source { 'jenkins':
-	      location    => 'http://pkg.jenkins-ci.org/debian-stable',
-	      release     => 'binary/',
-	      repos       => '',
-	      key         => 'D50582E6',
-	      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-	      include_src => false,
-	    }
+  }
+  elsif $lts == 1 {
+    apt::source { 'jenkins':
+      location    => 'http://pkg.jenkins-ci.org/debian-stable',
+      release     => 'binary/',
+      repos       => '',
+      key         => 'D50582E6',
+      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      include_src => false,
     }
-  
+  }
 }


### PR DESCRIPTION
Added $lts parameter to Debian manifest and used it via `$::jenkins::repo::lts`. If this has any other consequences for puppet dynamic scoping changes in version 3 I'm not sure about. At least the manifest worked on Ubuntu 12.10 and 12.04 using puppet 2.7.x and 3.0.2 in Vagrant boxes and real hardware. ;)

Also refs #45 and refs #42
