### PR TITLE
Invalid Parameter lts

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,4 +1,5 @@
-class jenkins::repo::debian {
+class jenkins::repo::debian ( $lts=0 )
+{
 
   include 'jenkins::repo'
 


### PR DESCRIPTION
Hi, I've simplified the last couple of pull requests you've had for this issue, in the hope that it builds and you can merge it.

Running this config:

``` ruby
jenkins: {
      class { 'jenkins':
        repo    => 1,
        version => 'latest',
      }
}
```

Currently renders this error:

``` ruby
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid parameter lts at /home/acaire/code/puppet-cloud/modules/jenkins/manifests/repo.pp:28 on node
```

Adding the parameter alone fixes it, at least in Puppet 3.1.1.
