### PR TITLE
Resolve 'invalid tag' error on puppet 2.7.20 with puppetlabs-firewall module installed.

### DIFF
--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -1,6 +1,6 @@
 class jenkins::firewall {
   if defined('::firewall') {
-    ::firewall {
+    firewall {
       '500 allow Jenkins inbound traffic':
         action => 'accept',
         state  => 'NEW',


### PR DESCRIPTION
...e the 'error Invalid tag "::firewall"' on puppet 2.7.20 with the puppetlabs-firewall module installed, and still successfully ensures the firewall rule in iptables.
